### PR TITLE
fix: 컴포넌트 내의 svg 속성값 카멜케이스로 변경

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,10 @@
-import { useState } from "react";
-import reactLogo from "./assets/react.svg";
-import viteLogo from "/vite.svg";
 import Home from "./pages/Home.jsx";
 import "./App.css";
 
 export default function App() {
-    return (
-        <div className="App">
-            <Home />
-        </div>
-    );
-};
+  return (
+    <div className="App">
+      <Home />
+    </div>
+  );
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,118 +1,152 @@
-import '../styles/Footer.css'
+import "../styles/Footer.css";
 
 export default function ContentSection() {
-    return (
-        <div className='Footer'>
-            <div className='footer-container'>
-                <div className="social-links">
-                    <button className="social-link">
-                        <svg xmlns="http://www.w3.org/2000/svg" 
-                            fill="none" role="img" viewBox="0 0 24 24" 
-                            width="24" height="24" data-icon="FacebookStandard" 
-                            aria-hidden="true" className="facebook-logo">
-                            <path fill="currentColor" 
-                                d="M13.987 13.1621V21.9841H10.042V13.1621H6.84198V9.51207H10.047V6.73207C10.047 3.56707 11.932 1.82007 14.815 1.82007C15.7618 1.83321 16.7063 1.91577 17.641 2.06707V5.17307H16.045C15.4954 5.10007 14.9424 5.28088 14.5421 5.66447C14.1417 6.04807 13.9375 6.59284 13.987 7.14507V9.51207H17.487L16.928 13.1621H13.987Z" 
-                                clip-rule="evenodd" fill-rule="evenodd">    
-                            </path>
-                        </svg>
-                    </button>
-                    <button className="social-link">
-                        <svg xmlns="http://www.w3.org/2000/svg" 
-                            fill="none" role="img" viewBox="0 0 24 24" 
-                            width="24" height="24" data-icon="InstagramStandard" 
-                            aria-hidden="true" className="instagram-logo">
-                            <path fill="currentColor" 
-                                d="M21.93 16.123C21.9584 17.6765 21.3789 19.1796 20.315 20.312C19.1851 21.3804 17.6797 21.9607 16.125 21.927C14.474 22.021 9.52499 22.021 7.87499 21.927C6.32126 21.9551 4.81792 21.3757 3.68499 20.312C2.61754 19.1819 2.03744 17.6772 2.06999 16.123C1.97699 14.472 1.97699 9.523 2.06999 7.873C2.03955 6.31886 2.61933 4.81466 3.68499 3.683C4.81767 2.61952 6.32162 2.04163 7.87499 2.073C9.52599 1.979 14.475 1.979 16.125 2.073C17.6789 2.04394 19.1826 2.62353 20.315 3.688C21.3825 4.81813 21.9625 6.32278 21.93 7.877C22.023 9.528 22.023 14.472 21.93 16.123ZM20.2 12C20.2 10.545 20.32 7.422 19.8 6.106C19.4572 5.23679 18.7692 4.54875 17.9 4.206C16.588 3.689 13.461 3.806 12.006 3.806C10.551 3.806 7.42799 3.685 6.11199 4.206C5.24298 4.54905 4.55505 5.23699 4.21199 6.106C3.69499 7.418 3.81199 10.545 3.81199 12C3.81199 13.455 3.69099 16.578 4.21199 17.894C4.55535 18.7628 5.24318 19.4506 6.11199 19.794C7.42399 20.311 10.552 20.194 12.006 20.194C13.46 20.194 16.584 20.315 17.9 19.794C18.769 19.451 19.4569 18.763 19.8 17.894C20.319 16.582 20.2 13.455 20.2 12ZM17.13 12C17.13 14.8312 14.8352 17.1264 12.004 17.127C9.17282 17.1276 6.8771 14.8332 6.87599 12.002C6.87489 9.17083 9.16882 6.87466 12 6.87299C13.3608 6.87034 14.6666 7.40959 15.629 8.37161C16.5914 9.33363 17.1311 10.6392 17.129 12H17.13ZM15.336 12C15.336 10.1596 13.8444 8.66756 12.004 8.667C10.1636 8.66645 8.6711 10.1576 8.66999 11.998C8.66889 13.8384 10.1596 15.3313 12 15.333C13.8406 15.3319 15.3328 13.8406 15.335 12H15.336ZM17.336 7.85901C16.6733 7.85901 16.136 7.32174 16.136 6.659C16.136 5.99626 16.6733 5.459 17.336 5.459C17.9987 5.459 18.536 5.99626 18.536 6.659C18.5379 6.97731 18.4124 7.28317 18.1876 7.50853C17.9628 7.73389 17.6573 7.86008 17.339 7.85901H17.336Z" 
-                                clip-rule="evenodd" fill-rule="evenodd">    
-                            </path>
-                        </svg>
-                    </button>
-                    <button className="social-link">
-                        <svg xmlns="http://www.w3.org/2000/svg" 
-                            fill="none" role="img" viewBox="0 0 24 24" 
-                            width="24" height="24" data-icon="TwitterStandard" 
-                            aria-hidden="true" className="twitter-logo">
-                            <path fill="currentColor" 
-                                d="M20.768 8.207C20.7914 11.5932 19.4565 14.8475 17.062 17.242C14.6675 19.6365 11.4132 20.9714 8.027 20.948C5.58923 20.9544 3.20152 20.2564 1.151 18.938C1.50998 18.9771 1.87091 18.9955 2.232 18.993C4.24768 18.9984 6.20639 18.3245 7.792 17.08C5.87438 17.0472 4.18971 15.799 3.6 13.974C3.87982 14.0187 4.16264 14.0421 4.446 14.044C4.84354 14.0428 5.23935 13.9914 5.624 13.891C3.53637 13.4667 2.0367 11.6303 2.038 9.5V9.441C2.65835 9.78765 3.3519 9.98262 4.062 10.01C2.08979 8.69332 1.48225 6.06954 2.675 4.02C4.94972 6.82016 8.30596 8.52336 11.909 8.706C11.8375 8.369 11.8009 8.02551 11.8 7.681C11.8014 5.84295 12.9248 4.19204 14.6341 3.51625C16.3434 2.84047 18.2921 3.2768 19.55 4.617C20.5522 4.42342 21.5131 4.05731 22.39 3.535C22.0556 4.56894 21.3555 5.44538 20.421 6C21.3102 5.89965 22.1795 5.66709 23 5.31C22.3866 6.20228 21.6273 6.98489 20.754 7.625C20.768 7.82 20.768 8.014 20.768 8.207Z" 
-                                clip-rule="evenodd" fill-rule="evenodd">
-                            </path>
-                        </svg>
-                    </button>
-                    <button className="social-link">
-                        <svg xmlns="http://www.w3.org/2000/svg" 
-                            fill="none" role="img" viewBox="0 0 24 24" 
-                            width="24" height="24" data-icon="YoutubeStandard" 
-                            aria-hidden="true" className="youtube-logo">
-                            <path fill="currentColor" 
-                                d="M22.54 6.67C22.288 5.71873 21.549 4.97331 20.6 4.713C18.88 4.25 12 4.25 12 4.25C12 4.25 5.11997 4.25 3.39997 4.713C2.45094 4.97331 1.71199 5.71873 1.45997 6.67C1.14265 8.42869 0.988663 10.213 0.99997 12C0.988663 13.787 1.14265 15.5713 1.45997 17.33C1.71288 18.2825 2.45401 19.0282 3.40497 19.287C5.11997 19.75 12.005 19.75 12.005 19.75C12.005 19.75 18.885 19.75 20.6 19.287C21.549 19.0267 22.288 18.2813 22.54 17.33C22.8573 15.5713 23.0113 13.787 23 12C23.0113 10.213 22.8573 8.42869 22.54 6.67ZM9.74997 15.27V8.729L15.5 12L9.74997 15.27Z" 
-                                clip-rule="evenodd" fill-rule="evenodd">
-                            </path>
-                        </svg>
-                    </button>
-                </div>
-            </div>
-            <div className='footer-link-grid'>
-                <ul className="member-footer-links">
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-
-                </ul>    
-                
-                <ul className="member-footer-links">
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                </ul>
-
-                <ul className="member-footer-links">
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                </ul>
-                <ul className="member-footer-links">
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                    <li className="member-footer-link">
-                        <span>이름</span>
-                    </li>
-                </ul>
-            </div>
-
-            <button className="member-footer-service">서비스 코드</button>
-
-            <div className="member-footer-copyright">
-                <div className="copy-text-block">내용</div>
-                <div className="copy-text-block">내용</div>
-                <div className="copy-text-block">내용</div>
-                <div className="copy-text-block">내용</div>
-                <div className="copy-text-block">내용</div>
-                <div className="copy-text-block">내용</div>
-                <div className="copy-text-block">내용</div>
-
-            </div>
+  return (
+    <div className="Footer">
+      <div className="footer-container">
+        <div className="social-links">
+          <button className="social-link">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              height="24"
+              data-icon="FacebookStandard"
+              aria-hidden="true"
+              className="facebook-logo"
+            >
+              <path
+                fill="currentColor"
+                d="M13.987 13.1621V21.9841H10.042V13.1621H6.84198V9.51207H10.047V6.73207C10.047 3.56707 11.932 1.82007 14.815 1.82007C15.7618 1.83321 16.7063 1.91577 17.641 2.06707V5.17307H16.045C15.4954 5.10007 14.9424 5.28088 14.5421 5.66447C14.1417 6.04807 13.9375 6.59284 13.987 7.14507V9.51207H17.487L16.928 13.1621H13.987Z"
+                clipRule="evenodd"
+                fillRule="evenodd"
+              ></path>
+            </svg>
+          </button>
+          <button className="social-link">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              height="24"
+              data-icon="InstagramStandard"
+              aria-hidden="true"
+              className="instagram-logo"
+            >
+              <path
+                fill="currentColor"
+                d="M21.93 16.123C21.9584 17.6765 21.3789 19.1796 20.315 20.312C19.1851 21.3804 17.6797 21.9607 16.125 21.927C14.474 22.021 9.52499 22.021 7.87499 21.927C6.32126 21.9551 4.81792 21.3757 3.68499 20.312C2.61754 19.1819 2.03744 17.6772 2.06999 16.123C1.97699 14.472 1.97699 9.523 2.06999 7.873C2.03955 6.31886 2.61933 4.81466 3.68499 3.683C4.81767 2.61952 6.32162 2.04163 7.87499 2.073C9.52599 1.979 14.475 1.979 16.125 2.073C17.6789 2.04394 19.1826 2.62353 20.315 3.688C21.3825 4.81813 21.9625 6.32278 21.93 7.877C22.023 9.528 22.023 14.472 21.93 16.123ZM20.2 12C20.2 10.545 20.32 7.422 19.8 6.106C19.4572 5.23679 18.7692 4.54875 17.9 4.206C16.588 3.689 13.461 3.806 12.006 3.806C10.551 3.806 7.42799 3.685 6.11199 4.206C5.24298 4.54905 4.55505 5.23699 4.21199 6.106C3.69499 7.418 3.81199 10.545 3.81199 12C3.81199 13.455 3.69099 16.578 4.21199 17.894C4.55535 18.7628 5.24318 19.4506 6.11199 19.794C7.42399 20.311 10.552 20.194 12.006 20.194C13.46 20.194 16.584 20.315 17.9 19.794C18.769 19.451 19.4569 18.763 19.8 17.894C20.319 16.582 20.2 13.455 20.2 12ZM17.13 12C17.13 14.8312 14.8352 17.1264 12.004 17.127C9.17282 17.1276 6.8771 14.8332 6.87599 12.002C6.87489 9.17083 9.16882 6.87466 12 6.87299C13.3608 6.87034 14.6666 7.40959 15.629 8.37161C16.5914 9.33363 17.1311 10.6392 17.129 12H17.13ZM15.336 12C15.336 10.1596 13.8444 8.66756 12.004 8.667C10.1636 8.66645 8.6711 10.1576 8.66999 11.998C8.66889 13.8384 10.1596 15.3313 12 15.333C13.8406 15.3319 15.3328 13.8406 15.335 12H15.336ZM17.336 7.85901C16.6733 7.85901 16.136 7.32174 16.136 6.659C16.136 5.99626 16.6733 5.459 17.336 5.459C17.9987 5.459 18.536 5.99626 18.536 6.659C18.5379 6.97731 18.4124 7.28317 18.1876 7.50853C17.9628 7.73389 17.6573 7.86008 17.339 7.85901H17.336Z"
+                clipRule="evenodd"
+                fillRule="evenodd"
+              ></path>
+            </svg>
+          </button>
+          <button className="social-link">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              height="24"
+              data-icon="TwitterStandard"
+              aria-hidden="true"
+              className="twitter-logo"
+            >
+              <path
+                fill="currentColor"
+                d="M20.768 8.207C20.7914 11.5932 19.4565 14.8475 17.062 17.242C14.6675 19.6365 11.4132 20.9714 8.027 20.948C5.58923 20.9544 3.20152 20.2564 1.151 18.938C1.50998 18.9771 1.87091 18.9955 2.232 18.993C4.24768 18.9984 6.20639 18.3245 7.792 17.08C5.87438 17.0472 4.18971 15.799 3.6 13.974C3.87982 14.0187 4.16264 14.0421 4.446 14.044C4.84354 14.0428 5.23935 13.9914 5.624 13.891C3.53637 13.4667 2.0367 11.6303 2.038 9.5V9.441C2.65835 9.78765 3.3519 9.98262 4.062 10.01C2.08979 8.69332 1.48225 6.06954 2.675 4.02C4.94972 6.82016 8.30596 8.52336 11.909 8.706C11.8375 8.369 11.8009 8.02551 11.8 7.681C11.8014 5.84295 12.9248 4.19204 14.6341 3.51625C16.3434 2.84047 18.2921 3.2768 19.55 4.617C20.5522 4.42342 21.5131 4.05731 22.39 3.535C22.0556 4.56894 21.3555 5.44538 20.421 6C21.3102 5.89965 22.1795 5.66709 23 5.31C22.3866 6.20228 21.6273 6.98489 20.754 7.625C20.768 7.82 20.768 8.014 20.768 8.207Z"
+                clipRule="evenodd"
+                fillRule="evenodd"
+              ></path>
+            </svg>
+          </button>
+          <button className="social-link">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              height="24"
+              data-icon="YoutubeStandard"
+              aria-hidden="true"
+              className="youtube-logo"
+            >
+              <path
+                fill="currentColor"
+                d="M22.54 6.67C22.288 5.71873 21.549 4.97331 20.6 4.713C18.88 4.25 12 4.25 12 4.25C12 4.25 5.11997 4.25 3.39997 4.713C2.45094 4.97331 1.71199 5.71873 1.45997 6.67C1.14265 8.42869 0.988663 10.213 0.99997 12C0.988663 13.787 1.14265 15.5713 1.45997 17.33C1.71288 18.2825 2.45401 19.0282 3.40497 19.287C5.11997 19.75 12.005 19.75 12.005 19.75C12.005 19.75 18.885 19.75 20.6 19.287C21.549 19.0267 22.288 18.2813 22.54 17.33C22.8573 15.5713 23.0113 13.787 23 12C23.0113 10.213 22.8573 8.42869 22.54 6.67ZM9.74997 15.27V8.729L15.5 12L9.74997 15.27Z"
+                clipRule="evenodd"
+                fillRule="evenodd"
+              ></path>
+            </svg>
+          </button>
         </div>
-    );
+      </div>
+      <div className="footer-link-grid">
+        <ul className="member-footer-links">
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+        </ul>
+
+        <ul className="member-footer-links">
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+        </ul>
+
+        <ul className="member-footer-links">
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+        </ul>
+        <ul className="member-footer-links">
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+          <li className="member-footer-link">
+            <span>이름</span>
+          </li>
+        </ul>
+      </div>
+
+      <button className="member-footer-service">서비스 코드</button>
+
+      <div className="member-footer-copyright">
+        <div className="copy-text-block">내용</div>
+        <div className="copy-text-block">내용</div>
+        <div className="copy-text-block">내용</div>
+        <div className="copy-text-block">내용</div>
+        <div className="copy-text-block">내용</div>
+        <div className="copy-text-block">내용</div>
+        <div className="copy-text-block">내용</div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -82,7 +82,7 @@ export default function Header() {
           <div className="account-tab">
             <img
               className="profile-icon"
-              src="https://occ-0-8133-58.1.nflxso.net/dnm/api/v6/vN7bi_My87NPKvsBoib006Llxzg/AAAABTZ2zlLdBVC05fsd2YQAR43J6vB1NAUBOOrxt7oaFATxMhtdzlNZ846H3D8TZzooe2-FT853YVYs8p001KVFYopWi4D4NXM.png?r=229"
+              src="https://occ-0-8232-988.1.nflxso.net/dnm/api/v6/vN7bi_My87NPKvsBoib006Llxzg/AAAABTZ2zlLdBVC05fsd2YQAR43J6vB1NAUBOOrxt7oaFATxMhtdzlNZ846H3D8TZzooe2-FT853YVYs8p001KVFYopWi4D4NXM.png?r=229"
               alt=""
             />
           </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,62 +1,93 @@
-import '../styles/Header.css';
+import "../styles/Header.css";
 
 export default function Header() {
-    return (
-        <div className="HeaderNav">
-            <div className='primary-navigation'>
-            <a href="/" className="netflix-logo-btn">
-                <img src="https://assets.nflxext.com/en_us/layout/ecweb/common/logo-shadow2x.png" alt="Netflix Logo" />
+  return (
+    <div className="HeaderNav">
+      <div className="primary-navigation">
+        <a href="/" className="netflix-logo-btn">
+          <img
+            src="https://assets.nflxext.com/en_us/layout/ecweb/common/logo-shadow2x.png"
+            alt="Netflix Logo"
+          />
+        </a>
+        <ul className="navigation">
+          <li className="nav-tab">
+            <a href="" id="nav-menu">
+              메뉴
             </a>
-            <ul className="navigation">
-                <li className="nav-tab">
-                    <a href="" id="nav-menu">메뉴</a>
+          </li>
+          <li className="nav-tab">
+            <a href="" id="current-active">
+              홈
+            </a>
+          </li>
+          <li className="nav-tab">
+            <a href="" id="genreCategory">
+              시리즈
+            </a>
+          </li>
+          <li className="nav-tab">
+            <a href="" id="genreCategory">
+              영화
+            </a>
+          </li>
+        </ul>
+      </div>
 
-                </li>
-                <li className="nav-tab">
-                    <a href="" id="current-active">홈</a>
-                </li>
-                <li className="nav-tab">
-                    <a href="" id="genreCategory">시리즈</a>
-                </li>
-                <li className="nav-tab">
-                <a href="" id="genreCategory">영화</a>
-                </li>
-            </ul>
-            </div>
-    
-            <div className="secondary-navigation">
-                <div className="nav-element">
-                    <button className="search-tab">
-                        <svg xmlns="http://www.w3.org/2000/svg" 
-                            fill="none" role="img" viewBox="0 0 24 24" 
-                            width="24" height="24" data-icon="MagnifyingGlassStandard" 
-                            aria-hidden="true" className="search-icon">
-                                <path fill-rule="evenodd" clip-rule="evenodd"
-                                    d="M17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10ZM15.6177 17.0319C14.078 18.2635 12.125 19 10 19C5.02944 19 1 14.9706 1 10C1 5.02944 5.02944 1 10 1C14.9706 1 19 5.02944 19 10C19 12.125 18.2635 14.078 17.0319 15.6177L22.7071 21.2929L21.2929 22.7071L15.6177 17.0319Z"
-                                    fill="currentColor">
-                                </path>
-                        </svg>
-                    </button>
-                </div>
-                <div className="nav-element">
-                    <button className="notifications-tab">
-                        <svg xmlns="http://www.w3.org/2000/svg" 
-                            fill="none" role="img" viewBox="0 0 24 24" 
-                            width="24" height="24" data-icon="BellStandard" 
-                            aria-hidden="true">
-                            <path fill-rule="evenodd" clip-rule="evenodd" 
-                                d="M13.0002 4.07092C16.3924 4.55624 19 7.4736 19 11V15.2538C20.0489 15.3307 21.0851 15.4245 22.1072 15.5347L21.8928 17.5232C18.7222 17.1813 15.4092 17 12 17C8.59081 17 5.27788 17.1813 2.10723 17.5232L1.89282 15.5347C2.91498 15.4245 3.95119 15.3307 5.00003 15.2538V11C5.00003 7.47345 7.60784 4.55599 11.0002 4.07086V2H13.0002V4.07092ZM17 15.1287V11C17 8.23858 14.7614 6 12 6C9.2386 6 7.00003 8.23858 7.00003 11V15.1287C8.64066 15.0437 10.3091 15 12 15C13.691 15 15.3594 15.0437 17 15.1287ZM8.62593 19.3712C8.66235 20.5173 10.1512 22 11.9996 22C13.848 22 15.3368 20.5173 15.3732 19.3712C15.3803 19.1489 15.1758 19 14.9533 19H9.0458C8.82333 19 8.61886 19.1489 8.62593 19.3712Z" 
-                                fill="currentColor">
-                            </path>
-                        </svg>
-                    </button>
-                </div>
-                <div className="nav-element">
-                    <div className="account-tab">
-                        <img className="profile-icon" src="https://occ-0-8133-58.1.nflxso.net/dnm/api/v6/vN7bi_My87NPKvsBoib006Llxzg/AAAABTZ2zlLdBVC05fsd2YQAR43J6vB1NAUBOOrxt7oaFATxMhtdzlNZ846H3D8TZzooe2-FT853YVYs8p001KVFYopWi4D4NXM.png?r=229" alt=""/>
-                    </div> 
-                </div>
-            </div>
+      <div className="secondary-navigation">
+        <div className="nav-element">
+          <button className="search-tab">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              height="24"
+              data-icon="MagnifyingGlassStandard"
+              aria-hidden="true"
+              className="search-icon"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10ZM15.6177 17.0319C14.078 18.2635 12.125 19 10 19C5.02944 19 1 14.9706 1 10C1 5.02944 5.02944 1 10 1C14.9706 1 19 5.02944 19 10C19 12.125 18.2635 14.078 17.0319 15.6177L22.7071 21.2929L21.2929 22.7071L15.6177 17.0319Z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </button>
         </div>
-    )
+        <div className="nav-element">
+          <button className="notifications-tab">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              height="24"
+              data-icon="BellStandard"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M13.0002 4.07092C16.3924 4.55624 19 7.4736 19 11V15.2538C20.0489 15.3307 21.0851 15.4245 22.1072 15.5347L21.8928 17.5232C18.7222 17.1813 15.4092 17 12 17C8.59081 17 5.27788 17.1813 2.10723 17.5232L1.89282 15.5347C2.91498 15.4245 3.95119 15.3307 5.00003 15.2538V11C5.00003 7.47345 7.60784 4.55599 11.0002 4.07086V2H13.0002V4.07092ZM17 15.1287V11C17 8.23858 14.7614 6 12 6C9.2386 6 7.00003 8.23858 7.00003 11V15.1287C8.64066 15.0437 10.3091 15 12 15C13.691 15 15.3594 15.0437 17 15.1287ZM8.62593 19.3712C8.66235 20.5173 10.1512 22 11.9996 22C13.848 22 15.3368 20.5173 15.3732 19.3712C15.3803 19.1489 15.1758 19 14.9533 19H9.0458C8.82333 19 8.61886 19.1489 8.62593 19.3712Z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </button>
+        </div>
+        <div className="nav-element">
+          <div className="account-tab">
+            <img
+              className="profile-icon"
+              src="https://occ-0-8133-58.1.nflxso.net/dnm/api/v6/vN7bi_My87NPKvsBoib006Llxzg/AAAABTZ2zlLdBVC05fsd2YQAR43J6vB1NAUBOOrxt7oaFATxMhtdzlNZ846H3D8TZzooe2-FT853YVYs8p001KVFYopWi4D4NXM.png?r=229"
+              alt=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/TrailerSection.jsx
+++ b/src/components/TrailerSection.jsx
@@ -1,101 +1,133 @@
-import '../styles/TrailerSection.css';
+import "../styles/TrailerSection.css";
 
 export default function Header() {
-    return (
-        <div className="trailer">
-            <div className="trailer-video">
-            <video
-                src="/videos/trailer.mp4"
-                autoPlay
-                muted
-                loop
-            />
+  return (
+    <div className="trailer">
+      <div className="trailer-video">
+        <video src="/videos/trailer.mp4" autoPlay muted loop />
+      </div>
+
+      <div className="trailer-wrapper">
+        <div className="trailer-left">
+          <div className="trailer-meta">
+            <div className="trailer-container">
+              <div className="trailer-title">
+                <h2>제목</h2>
+              </div>
+              <p className="trailer-description">부가설명</p>
             </div>
+          </div>
 
-            <div className='trailer-wrapper'>
-                <div className='trailer-left'>
-                    <div className="trailer-meta">
-                        <div className="trailer-container">
-                            <div className="trailer-title">
-                                <h2>제목</h2>
-                            </div>
-                            <p className="trailer-description">부가설명</p>
-                        </div>                       
-                    </div>
-
-                    <div className="trailer-actions">
-                        <div className='trailer-actions-btns'>
-                            <button className='play-btn'>
-                                <svg xmlns="http://www.w3.org/2000/svg" 
-                                    fill="none" role="img" 
-                                    viewBox="0 0 24 24" 
-                                    width="24" height="24" data-icon="PlayStandard" 
-                                    aria-hidden="true">
-                                    <path fill="currentColor" 
-                                    d="M5 2.69127C5 1.93067 5.81547 1.44851 6.48192 1.81506L23.4069 11.1238C24.0977 11.5037 24.0977 12.4963 23.4069 12.8762L6.48192 22.1849C5.81546 22.5515 5 22.0693 5 21.3087V2.69127Z">
-                                    </path>
-                                </svg>
-                                <span>재생</span>
-                                </button>
-                            <button className='info-btn'>
-                                <svg xmlns="http://www.w3.org/2000/svg" 
-                                    fill="none" role="img" 
-                                    viewBox="0 0 24 24" 
-                                    width="24" height="24" data-icon="CircleIStandard" 
-                                    aria-hidden="true">
-                                    <path fill="currentColor" 
-                                        d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2ZM0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12ZM13 10V18H11V10H13ZM12 8.5C12.8284 8.5 13.5 7.82843 13.5 7C13.5 6.17157 12.8284 5.5 12 5.5C11.1716 5.5 10.5 6.17157 10.5 7C10.5 7.82843 11.1716 8.5 12 8.5Z" 
-                                        clip-rule="evenodd" fill-rule="evenodd"></path>
-
-                                </svg>
-                                <span>상세 정보</span>
-                            </button>
-                        </div>
-                    </div>
-                </div>
-                    
-                <div className="trailer-controls">
-                    <div className='trailer-controls-btns'>
-                        <button className='retry-btn'>
-                            <svg xmlns="http://www.w3.org/2000/svg" 
-                                fill="none" role="img" viewBox="0 0 24 24" 
-                                width="24" height="24" data-icon="RefreshStandard" 
-                                aria-hidden="true">
-                                <path fill="currentColor" 
-                                    d="M20.6625 7C18.9328 4.00995 15.7002 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12H24C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12C0 5.37258 5.37258 0 12 0C16.1752 0 19.8508 2.13204 22 5.36482V2H24V8C24 8.55228 23.5523 9 23 9H17V7H20.6625Z" 
-                                    clip-rule="evenodd" fill-rule="evenodd">
-                                </path>
-                            </svg>
-                        </button>
-                        <button className='audio-btn'>
-                            <svg xmlns="http://www.w3.org/2000/svg" 
-                                fill="none" role="img" viewBox="0 0 24 24" 
-                                width="24" height="24" data-icon="VolumeHighStandard" 
-                                aria-hidden="true">
-                                <path fill="currentColor" 
-                                    d="M24 12C24 8.28693 22.525 4.72597 19.8995 2.10046L18.4853 3.51468C20.7357 5.76511 22 8.81736 22 12C22 15.1826 20.7357 18.2348 18.4853 20.4852L19.8995 21.8995C22.525 19.2739 24 15.713 24 12ZM11 3.99995C11 3.59549 10.7564 3.23085 10.3827 3.07607C10.009 2.92129 9.57889 3.00685 9.29289 3.29285L4.58579 7.99995H1C0.447715 7.99995 0 8.44767 0 8.99995V15C0 15.5522 0.447715 16 1 16H4.58579L9.29289 20.7071C9.57889 20.9931 10.009 21.0786 10.3827 20.9238C10.7564 20.7691 11 20.4044 11 20V3.99995ZM5.70711 9.70706L9 6.41417V17.5857L5.70711 14.2928L5.41421 14H5H2V9.99995H5H5.41421L5.70711 9.70706ZM16.0001 12C16.0001 10.4087 15.368 8.88254 14.2428 7.75732L12.8285 9.17154C13.5787 9.92168 14.0001 10.9391 14.0001 12C14.0001 13.0608 13.5787 14.0782 12.8285 14.8284L14.2428 16.2426C15.368 15.1174 16.0001 13.5913 16.0001 12ZM17.0709 4.92889C18.9462 6.80426 19.9998 9.3478 19.9998 12C19.9998 14.6521 18.9462 17.1957 17.0709 19.071L15.6567 17.6568C17.157 16.1565 17.9998 14.1217 17.9998 12C17.9998 9.87823 17.157 7.8434 15.6567 6.34311L17.0709 4.92889Z" 
-                                    clip-rule="evenodd" fill-rule="evenodd">
-                                </path>
-                            </svg>
-                        </button>
-                        <button className='mute-btn'>
-                            <svg xmlns="http://www.w3.org/2000/svg" 
-                                fill="none" role="img" viewBox="0 0 24 24" 
-                                width="24" height="24" data-icon="VolumeOffStandard" 
-                                aria-hidden="true">
-                                <path fill="currentColor" 
-                                    d="M11 4.00003C11 3.59557 10.7564 3.23093 10.3827 3.07615C10.009 2.92137 9.57889 3.00692 9.29289 3.29292L4.58579 8.00003H1C0.447715 8.00003 0 8.44774 0 9.00003V15C0 15.5523 0.447715 16 1 16H4.58579L9.29289 20.7071C9.57889 20.9931 10.009 21.0787 10.3827 20.9239C10.7564 20.7691 11 20.4045 11 20V4.00003ZM5.70711 9.70714L9 6.41424V17.5858L5.70711 14.2929L5.41421 14H5H2V10H5H5.41421L5.70711 9.70714ZM15.2929 9.70714L17.5858 12L15.2929 14.2929L16.7071 15.7071L19 13.4142L21.2929 15.7071L22.7071 14.2929L20.4142 12L22.7071 9.70714L21.2929 8.29292L19 10.5858L16.7071 8.29292L15.2929 9.70714Z" 
-                                    clip-rule="evenodd" fill-rule="evenodd">
-                                </path>
-                            </svg>
-                        </button>
-                    </div>
-                    {/* 트레일러 영상 중에는 소리 조절 버튼 / 영상 끝난 시점엔 새로고침 버튼이 나타남 */}
-                    <div className='age-badge'>
-                        <span>15+</span>
-                    </div>
-                </div>
-            </div>        
+          <div className="trailer-actions">
+            <div className="trailer-actions-btns">
+              <button className="play-btn">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  height="24"
+                  data-icon="PlayStandard"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill="currentColor"
+                    d="M5 2.69127C5 1.93067 5.81547 1.44851 6.48192 1.81506L23.4069 11.1238C24.0977 11.5037 24.0977 12.4963 23.4069 12.8762L6.48192 22.1849C5.81546 22.5515 5 22.0693 5 21.3087V2.69127Z"
+                  ></path>
+                </svg>
+                <span>재생</span>
+              </button>
+              <button className="info-btn">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  height="24"
+                  data-icon="CircleIStandard"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill="currentColor"
+                    d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2ZM0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12ZM13 10V18H11V10H13ZM12 8.5C12.8284 8.5 13.5 7.82843 13.5 7C13.5 6.17157 12.8284 5.5 12 5.5C11.1716 5.5 10.5 6.17157 10.5 7C10.5 7.82843 11.1716 8.5 12 8.5Z"
+                    clipRule="evenodd"
+                    fillRule="evenodd"
+                  ></path>
+                </svg>
+                <span>상세 정보</span>
+              </button>
+            </div>
+          </div>
         </div>
-    )
+
+        <div className="trailer-controls">
+          <div className="trailer-controls-btns">
+            <button className="retry-btn">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                height="24"
+                data-icon="RefreshStandard"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M20.6625 7C18.9328 4.00995 15.7002 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12H24C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12C0 5.37258 5.37258 0 12 0C16.1752 0 19.8508 2.13204 22 5.36482V2H24V8C24 8.55228 23.5523 9 23 9H17V7H20.6625Z"
+                  clipRule="evenodd"
+                  fillRule="evenodd"
+                ></path>
+              </svg>
+            </button>
+            <button className="audio-btn">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                height="24"
+                data-icon="VolumeHighStandard"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M24 12C24 8.28693 22.525 4.72597 19.8995 2.10046L18.4853 3.51468C20.7357 5.76511 22 8.81736 22 12C22 15.1826 20.7357 18.2348 18.4853 20.4852L19.8995 21.8995C22.525 19.2739 24 15.713 24 12ZM11 3.99995C11 3.59549 10.7564 3.23085 10.3827 3.07607C10.009 2.92129 9.57889 3.00685 9.29289 3.29285L4.58579 7.99995H1C0.447715 7.99995 0 8.44767 0 8.99995V15C0 15.5522 0.447715 16 1 16H4.58579L9.29289 20.7071C9.57889 20.9931 10.009 21.0786 10.3827 20.9238C10.7564 20.7691 11 20.4044 11 20V3.99995ZM5.70711 9.70706L9 6.41417V17.5857L5.70711 14.2928L5.41421 14H5H2V9.99995H5H5.41421L5.70711 9.70706ZM16.0001 12C16.0001 10.4087 15.368 8.88254 14.2428 7.75732L12.8285 9.17154C13.5787 9.92168 14.0001 10.9391 14.0001 12C14.0001 13.0608 13.5787 14.0782 12.8285 14.8284L14.2428 16.2426C15.368 15.1174 16.0001 13.5913 16.0001 12ZM17.0709 4.92889C18.9462 6.80426 19.9998 9.3478 19.9998 12C19.9998 14.6521 18.9462 17.1957 17.0709 19.071L15.6567 17.6568C17.157 16.1565 17.9998 14.1217 17.9998 12C17.9998 9.87823 17.157 7.8434 15.6567 6.34311L17.0709 4.92889Z"
+                  clipRule="evenodd"
+                  fillRule="evenodd"
+                ></path>
+              </svg>
+            </button>
+            <button className="mute-btn">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                height="24"
+                data-icon="VolumeOffStandard"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M11 4.00003C11 3.59557 10.7564 3.23093 10.3827 3.07615C10.009 2.92137 9.57889 3.00692 9.29289 3.29292L4.58579 8.00003H1C0.447715 8.00003 0 8.44774 0 9.00003V15C0 15.5523 0.447715 16 1 16H4.58579L9.29289 20.7071C9.57889 20.9931 10.009 21.0787 10.3827 20.9239C10.7564 20.7691 11 20.4045 11 20V4.00003ZM5.70711 9.70714L9 6.41424V17.5858L5.70711 14.2929L5.41421 14H5H2V10H5H5.41421L5.70711 9.70714ZM15.2929 9.70714L17.5858 12L15.2929 14.2929L16.7071 15.7071L19 13.4142L21.2929 15.7071L22.7071 14.2929L20.4142 12L22.7071 9.70714L21.2929 8.29292L19 10.5858L16.7071 8.29292L15.2929 9.70714Z"
+                  clipRule="evenodd"
+                  fillRule="evenodd"
+                ></path>
+              </svg>
+            </button>
+          </div>
+          {/* 트레일러 영상 중에는 소리 조절 버튼 / 영상 끝난 시점엔 새로고침 버튼이 나타남 */}
+          <div className="age-badge">
+            <span>15+</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
# 설명

- 컴포넌트 내의 svg 속성값 카멜케이스로 변경
- clip-rule -> clipRule
- fill-rule -> fillRule
- [참고 사이트](https://stackoverflow.com/questions/54314284/how-to-resolve-warning-invalid-dom-property-fill-rule-did-you-mean-fillrul)
- 또한, 원인을 알 수 없는 cdn 링크 오류로 인해 프로필 이미지가 보이지 않는 이슈가 발생하여 링크 수정

Fixes #4 

## 변경 유형

- [x] 버그 수정

## 스크린샷 첨부
![Image](https://github.com/user-attachments/assets/998df6f2-c451-497f-a0ab-670bc1158730)
![image](https://github.com/user-attachments/assets/89f8e701-a41a-4176-803a-b92a1e270e5c)
![image](https://github.com/user-attachments/assets/1b81a2e7-2f21-459e-b32a-f38ebe5b6869)


